### PR TITLE
remove reload-plugin

### DIFF
--- a/odabot/cli.py
+++ b/odabot/cli.py
@@ -506,11 +506,7 @@ def update_workflows(obj, dry_run, force, loop, pattern):
                             logger.info('Deployment info %s', deployment_info)
                             
                             if workflow_update_status[project['http_url_to_repo']]['last_deployment_status'] == 'success':
-                                
-                                logger.info("updated: will reload nb2workflow-plugin")
-                                res = requests.get(f"{dispatcher_url.strip('/')}/reload-plugin/dispatcher_plugin_nb2workflow")
-                                assert res.status_code == 200
-                                
+                                                               
                                 # TODO: check live
                                 # oda-api -u staging get -i cta-example
                     


### PR DESCRIPTION
No more need to reload plugin after https://github.com/oda-hub/dispatcher-plugin-nb2workflow/pull/90
(it didn't work anyway due to multiple workers)