### PR TITLE
galaxy bot python 3.10

### DIFF
--- a/Dockerfile_galaxy
+++ b/Dockerfile_galaxy
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.10
 
 COPY . /source
 


### PR DESCRIPTION
Changes introduced in https://github.com/oda-hub/oda-bot/pull/77 require `python3.10` (`root_dir` parameter of `glob()`)